### PR TITLE
chore: fix invalid keys and update print width

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,11 +1,11 @@
 {
-  "printWidth": 80,
+  "printWidth": 100,
   "tabWidth": 2,
   "useTabs": false,
-  "semi": true,
+  "semi": false,
   "singleQuote": true,
   "trailingComma": "es5",
   "bracketSpacing": true,
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "arrowParens": "avoid"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solare/prettier-config",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Prettier Configuration",
   "main": "index.json",
   "scripts": {


### PR DESCRIPTION
- Print with 100 to make it work better with long tailwindcss classes.
- `jsxBracketSameLine` is no longer a valid key.
- Remove semi 🙂